### PR TITLE
Fix header parse bugs

### DIFF
--- a/stormed/serialization.py
+++ b/stormed/serialization.py
@@ -216,6 +216,11 @@ def table2str(d):
     return ''.join([ '%sS%s' % (dump_shortstr(k), dump_longstr(v))
                      for k, v in d.items() ])
 
+
+def dump_utf8longstr(s):
+    return '%s%s' % (longstr_header.pack(len(s)), s)
+
+
 def dump_table(d):
     entries = table2str(d)
-    return dump_longstr(entries)
+    return dump_utf8longstr(entries)


### PR DESCRIPTION
long utf-8 str header params may cause parse error.
